### PR TITLE
implement combineReducers

### DIFF
--- a/lib/combineReducers.lua
+++ b/lib/combineReducers.lua
@@ -1,0 +1,17 @@
+--[[
+	Create a composite reducer from a map of keys and sub-reducers.
+]]
+local function combineReducers(map)
+	return function(state, action)
+		local newState = {}
+
+		for key, reducer in pairs(map) do
+			-- Each reducer gets its own state, not the entire state table
+			newState[key] = reducer(state[key], action)
+		end
+
+		return newState
+	end
+end
+
+return combineReducers

--- a/lib/combineReducers.spec.lua
+++ b/lib/combineReducers.spec.lua
@@ -19,4 +19,19 @@ return function()
 		expect(aCount).to.equal(1)
 		expect(bCount).to.equal(1)
 	end)
+
+	it("should assign each sub-reducer's value to the new state", function()
+		local reducer = combineReducers({
+			a = function(state, action)
+				return (state or 0) + 1
+			end,
+			b = function(state, action)
+				return (state or 0) + 1
+			end,
+		})
+
+		local newState = reducer({}, {})
+		expect(newState.a).to.equal(1)
+		expect(newState.b).to.equal(1)
+	end)
 end

--- a/lib/combineReducers.spec.lua
+++ b/lib/combineReducers.spec.lua
@@ -26,12 +26,12 @@ return function()
 				return (state or 0) + 1
 			end,
 			b = function(state, action)
-				return (state or 0) + 1
+				return (state or 0) + 3
 			end,
 		})
 
 		local newState = reducer({}, {})
 		expect(newState.a).to.equal(1)
-		expect(newState.b).to.equal(1)
+		expect(newState.b).to.equal(3)
 	end)
 end

--- a/lib/combineReducers.spec.lua
+++ b/lib/combineReducers.spec.lua
@@ -1,0 +1,22 @@
+return function()
+	local combineReducers = require(script.Parent.combineReducers)
+
+	it("should invoke each sub-reducer for every action", function()
+		local aCount = 0
+		local bCount = 0
+
+		local reducer = combineReducers({
+			a = function(state, action)
+				aCount = aCount + 1
+			end,
+			b = function(state, action)
+				bCount = bCount + 1
+			end,
+		})
+
+		-- Mock reducer invocation
+		reducer({}, {})
+		expect(aCount).to.equal(1)
+		expect(bCount).to.equal(1)
+	end)
+end

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1,5 +1,7 @@
 local Store = require(script.Store)
+local combineReducers = require(script.combineReducers)
 
 return {
 	Store = Store,
+	combineReducers = combineReducers,
 }


### PR DESCRIPTION
This fixes #6. It adds a `combineReducers` function that works pretty much as expected:

```lua
combineReducers({
    a = function(state, action)
        -- state here is rootState.a
    end,
    b = function(state, action)
        -- state here is rootState.b
    end,
})
```