### PR TITLE
Add createReducer

### DIFF
--- a/lib/createReducer.lua
+++ b/lib/createReducer.lua
@@ -1,0 +1,15 @@
+return function(initialState, handlers)
+	return function(state, action)
+		if state == nil then
+			return initialState
+		end
+
+		local handler = handlers[action.type]
+
+		if handler then
+			return handler(state, action)
+		end
+
+		return state
+	end
+end

--- a/lib/createReducer.spec.lua
+++ b/lib/createReducer.spec.lua
@@ -1,0 +1,79 @@
+return function()
+	local createReducer = require(script.Parent.createReducer)
+
+	it("should handle actions", function()
+		local reducer = createReducer({
+			a = 0,
+			b = 0,
+		}, {
+			a = function(state, action)
+				return {
+					a = state.a + 1,
+					b = state.b
+				}
+			end,
+			b = function(state, action)
+				return {
+					a = state.a,
+					b = state.b + 2,
+				}
+			end,
+		})
+
+		local newState = reducer({
+			a = 0,
+			b = 0,
+		}, {
+			type = "a"
+		})
+
+		expect(newState.a).to.equal(1)
+
+		newState = reducer(newState, {
+			type = "b"
+		})
+
+		expect(newState.b).to.equal(2)
+	end)
+
+	it("should return the initial state if the state is nil", function()
+		local reducer = createReducer({
+			a = 0,
+			b = 0,
+		-- We don't care about the actions here
+		}, {})
+
+		local newState = reducer(nil, {})
+		expect(newState).to.be.ok()
+		expect(newState.a).to.equal(0)
+		expect(newState.b).to.equal(0)
+	end)
+
+	it("should return the same state if the action is not handled", function()
+		local initialState = {
+			a = 0,
+			b = 0,
+		}
+
+		local reducer = createReducer(initialState, {
+			a = function(state, action)
+				return {
+					a = state.a + 1,
+					b = state.b
+				}
+			end,
+			b = function(state, action)
+				return {
+					a = state.a,
+					b = state.b + 2,
+				}
+			end,
+		})
+
+		local newState = reducer(initialState, {
+			type = "c"
+		})
+
+		expect(newState).to.equal(initialState)
+	end)
+end

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1,5 +1,7 @@
 local Store = require(script.Store)
+local createReducer = require(script.createReducer)
 
 return {
 	Store = Store,
+	createReducer = createReducer,
 }


### PR DESCRIPTION
This fixes #7.

It adds a `createReducer` function that works effectively identically to the [redux-create-reducer](https://github.com/kolodny/redux-create-reducer) library. Example usage (taken from the tests):

```lua
local reducer = createReducer({
    a = 0,
    b = 0,
}, {
    a = function(state, action)
        return {
            a = state.a + 1,
            b = state.b
        }
    end,
    b = function(state, action)
        return {
            a = state.a,
            b = state.b + 2,
        }
    end,
})
```

The first argument is `initialState`, which will be returned if and only if the state provided to the reducer is `nil`. The second argument is a map of action types to reducer functions; the reducer corresponding to the action type will be used. If the action type is not in the map, the composite reducer will return the same value of `state` that it received.