### PR TITLE
Throw if missing action.type

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,7 +8,7 @@ stds.roblox = {
 
 		-- Extra functions
 		"tick", "warn", "spawn",
-		"wait", "settings",
+		"wait", "settings", "typeof",
 
 		-- Types
 		"Vector2", "Vector3",

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -24,7 +24,7 @@ Store.__index = Store
 	valid.
 ]]
 function Store.new(reducer, initialState)
-	assert(type(reducer) == "function", "Bad argument #1 to Store.new, expected function.")
+	assert(typeof(reducer) == "function", "Bad argument #1 to Store.new, expected function.")
 
 	local self = {
 		_reducer = reducer,
@@ -64,11 +64,11 @@ end
 	Pass a function to dispatch a thunk.
 ]]
 function Store:dispatch(action)
-	if type(action) == "function" then
+	if typeof(action) == "function" then
 		local result = action(self)
 
 		return result
-	elseif type(action) == "table" then
+	elseif typeof(action) == "table" then
 		if not action.type then
 			error("action does not have a type field", 0)
 		end

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -70,13 +70,13 @@ function Store:dispatch(action)
 		return result
 	elseif typeof(action) == "table" then
 		if action.type == nil then
-			error("action does not have a type field", 0)
+			error("action does not have a type field", 2)
 		end
 
 		self._state = self._reducer(self._state, action)
 		self._mutatedSinceFlush = true
 	else
-		error(("actions of type %q are not permitted"):format(typeof(action)))
+		error(("actions of type %q are not permitted"):format(typeof(action)), 2)
 	end
 end
 

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -69,7 +69,7 @@ function Store:dispatch(action)
 
 		return result
 	elseif typeof(action) == "table" then
-		if not action.type then
+		if action.type == nil then
 			error("action does not have a type field", 0)
 		end
 

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -68,9 +68,15 @@ function Store:dispatch(action)
 		local result = action(self)
 
 		return result
-	else
+	elseif type(action) == "table" then
+		if not action.type then
+			error("action does not have a type field", 0)
+		end
+
 		self._state = self._reducer(self._state, action)
 		self._mutatedSinceFlush = true
+	else
+		error(("actions of type %q are not permitted"):format(typeof(action)))
 	end
 end
 

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -120,11 +120,11 @@ return function()
 					value = 0
 				}
 
-				if action == "increment" then
+				if action.type == "increment" then
 					return {
 						value = state.value + 1
 					}
-				elseif action == "decrement" then
+				elseif action.type == "decrement" then
 					return {
 						value = state.value - 1
 					}
@@ -139,13 +139,17 @@ return function()
 				expect(state).never.to.equal(oldState)
 
 				if state.value > 0 then
-					store:dispatch("decrement")
+					store:dispatch({
+						type = "decrement"
+					})
 				end
 
 				changeCount = changeCount + 1
 			end)
 
-			store:dispatch("increment")
+			store:dispatch({
+				type = "increment"
+			})
 			store:flush()
 			store:flush()
 
@@ -169,7 +173,9 @@ return function()
 				postCount = postCount + 1
 			end)
 
-			store:dispatch("increment")
+			store:dispatch({
+				type = "increment"
+			})
 
 			expect(function()
 				store:flush()
@@ -177,6 +183,18 @@ return function()
 
 			expect(preCount).to.equal(1)
 			expect(postCount).to.equal(0)
+
+			store:destruct()
+		end)
+
+		it("should throw if an action is dispatched without a type field", function()
+			local store = Store.new(function(state, action)
+				return state
+			end)
+
+			expect(function()
+				store:dispatch({})
+			end).to.throw()
 
 			store:destruct()
 		end)
@@ -196,7 +214,9 @@ return function()
 
 			expect(count).to.equal(0)
 
-			store:dispatch("increment")
+			store:dispatch({
+				type = "increment"
+			})
 			store:flush()
 
 			expect(count).to.equal(1)

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -198,6 +198,18 @@ return function()
 
 			store:destruct()
 		end)
+
+		it("should throw if the action is not a function or table", function()
+			local store = Store.new(function(state, action)
+				return state
+			end)
+
+			expect(function()
+				store:dispatch(1)
+			end).to.throw()
+
+			store:destruct()
+		end)
 	end)
 
 	describe("Flush", function()


### PR DESCRIPTION
This patch builds on #10. It throws an error in two cases where Rodux did not before:
* If the action is missing a `type` field. This is an API requirement that Redux has, and it makes sense to have it here.
* If the action is not a table. The type of the value will be reported (using `typeof`).
