### PR TITLE
Middlewares

### DIFF
--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -25,6 +25,7 @@ Store.__index = Store
 ]]
 function Store.new(reducer, initialState, middlewares)
 	assert(typeof(reducer) == "function", "Bad argument #1 to Store.new, expected function.")
+	assert(middlewares == nil or typeof(middlewares) == "table", "Bad argument #3 to Store.new, expected nil or table.")
 
 	local self = {
 		_reducer = reducer,
@@ -44,12 +45,14 @@ function Store.new(reducer, initialState, middlewares)
 	end)
 	table.insert(self._connections, connection)
 
-	local dispatch = Store.dispatch
-	for _, middleware in ipairs(middlewares) do
-		dispatch = middleware(dispatch)
-	end
+	if middlewares then
+		local dispatch = Store.dispatch
+		for _, middleware in ipairs(middlewares) do
+			dispatch = middleware(dispatch)
+		end
 
-	self.dispatch = dispatch
+		self.dispatch = dispatch
+	end
 
 	return self
 end

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -23,7 +23,7 @@ Store.__index = Store
 	Reducers do not mutate the state object, so the original state is still
 	valid.
 ]]
-function Store.new(reducer, initialState)
+function Store.new(reducer, initialState, middlewares)
 	assert(typeof(reducer) == "function", "Bad argument #1 to Store.new, expected function.")
 
 	local self = {
@@ -43,6 +43,13 @@ function Store.new(reducer, initialState)
 		self:flush()
 	end)
 	table.insert(self._connections, connection)
+
+	local dispatch = Store.dispatch
+	for _, middleware in ipairs(middlewares) do
+		dispatch = middleware(dispatch)
+	end
+
+	self.dispatch = dispatch
 
 	return self
 end

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -49,7 +49,6 @@ return function()
 				end
 			})
 
-			expect(store.dispatch).to.never.equal(Store.dispatch)
 			store:dispatch({
 				type = "test"
 			})

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -23,6 +23,31 @@ return function()
 
 			store:destruct()
 		end)
+
+		it("should instantiate with a reducer, initial state, and middlewares", function()
+			local store = Store.new(function(state, action)
+				return state
+			end, "initial state", {})
+
+			expect(store).to.be.ok()
+			expect(store:getState()).to.equal("initial state")
+
+			store:destruct()
+		end)
+
+		it("should modify the dispatch method when middlewares are passed", function()
+			local store = Store.new(function(state, action)
+				return state
+			end, "initial state", {
+				function(next)
+					return function(store, action)
+						next(action)
+					end
+				end
+			})
+
+			expect(store.dispatch).to.never.equal(Store.dispatch)
+		end)
 	end)
 
 	describe("GetState", function()

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -54,6 +54,8 @@ return function()
 				type = "test"
 			})
 			expect(middlewareInvokeCount).to.equal(1)
+
+			store:destruct()
 		end)
 	end)
 

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -55,10 +55,10 @@ return function()
 				type = "test"
 			})
 
-            expect(middlewareInvokeCount).to.equal(1)
+			expect(middlewareInvokeCount).to.equal(1)
 
 			store:destruct()
-        end)
+		end)
 
 		it("should send an initial action with a 'type' field", function()
 			local lastAction

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -36,17 +36,24 @@ return function()
 		end)
 
 		it("should modify the dispatch method when middlewares are passed", function()
+			local middlewareInvokeCount = 0
+
 			local store = Store.new(function(state, action)
 				return state
 			end, "initial state", {
 				function(next)
 					return function(store, action)
-						next(action)
+						middlewareInvokeCount = middlewareInvokeCount + 1
+						next(store, action)
 					end
 				end
 			})
 
 			expect(store.dispatch).to.never.equal(Store.dispatch)
+			store:dispatch({
+				type = "test"
+			})
+			expect(middlewareInvokeCount).to.equal(1)
 		end)
 	end)
 

--- a/lib/Store.spec.lua
+++ b/lib/Store.spec.lua
@@ -38,20 +38,23 @@ return function()
 		it("should modify the dispatch method when middlewares are passed", function()
 			local middlewareInvokeCount = 0
 
-			local store = Store.new(function(state, action)
+			local function reducer(state, action)
 				return state
-			end, "initial state", {
-				function(next)
-					return function(store, action)
-						middlewareInvokeCount = middlewareInvokeCount + 1
-						next(store, action)
-					end
+			end
+
+			local function testMiddleware(next)
+				return function(store, action)
+					middlewareInvokeCount = middlewareInvokeCount + 1
+					next(store, action)
 				end
-			})
+			end
+
+			local store = Store.new(reducer, "initial state", { testMiddleware })
 
 			store:dispatch({
 				type = "test"
 			})
+
             expect(middlewareInvokeCount).to.equal(1)
 
 			store:destruct()

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1,9 +1,11 @@
 local Store = require(script.Store)
 local createReducer = require(script.createReducer)
 local combineReducers = require(script.combineReducers)
+local loggerMiddleware = require(script.loggerMiddleware)
 
 return {
 	Store = Store,
 	createReducer = createReducer,
 	combineReducers = combineReducers,
+	logger = loggerMiddleware,
 }

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -7,5 +7,5 @@ return {
 	Store = Store,
 	createReducer = createReducer,
 	combineReducers = combineReducers,
-	logger = loggerMiddleware,
+	loggerMiddleware = loggerMiddleware,
 }

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -30,12 +30,18 @@ local function prettyPrint(t, indent)
 	return table.concat(outputBuffer, "")
 end
 
-local function loggerPlugin(next)
-	return function(store, action)
-		print("Action dispatched:", prettyPrint(action))
-		next(store, action)
-		print("State changed to:", prettyPrint(store:getState()))
+local loggerPlugin = {}
+-- Allows the output function to be changed at runtime.
+loggerPlugin.outputFunction = print
+
+setmetatable(loggerPlugin, {
+	__call = function(_, next)
+		return function(store, action)
+			loggerPlugin.outputFunction("Action dispatched: "..prettyPrint(action))
+			next(store, action)
+			loggerPlugin.outputFunction("State changed to:"..prettyPrint(store:getState()))
+		end
 	end
-end
+})
 
 return loggerPlugin

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -13,7 +13,7 @@ local function prettyPrint(t, indent)
 		table.insert(outputBuffer, strKey)
 		table.insert(outputBuffer, " = ")
 
-		if type(value) == "table" then
+		if typeof(value) == "table" then
 			table.insert(outputBuffer, prettyPrint(value, indent + 1))
 			table.insert(outputBuffer, "\n")
 		else
@@ -35,9 +35,9 @@ local function loggerMiddleware(outputFunction)
 
 	return function(next)
 		return function(store, action)
-			outputFunction("Action dispatched: "..prettyPrint(action))
+			outputFunction("Action dispatched: " .. prettyPrint(action))
 			next(store, action)
-			outputFunction("State changed to:"..prettyPrint(store:getState()))
+			outputFunction("State changed to:" .. prettyPrint(store:getState()))
 		end
 	end
 end

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -37,7 +37,7 @@ local function loggerMiddleware(outputFunction)
 		return function(store, action)
 			outputFunction("Action dispatched: " .. prettyPrint(action))
 			next(store, action)
-			outputFunction("State changed to:" .. prettyPrint(store:getState()))
+			outputFunction("State changed to: " .. prettyPrint(store:getState()))
 		end
 	end
 end

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -33,7 +33,7 @@ end
 local function loggerPlugin(next)
 	return function(store, action)
 		print("Action dispatched:", prettyPrint(action))
-		next(action)
+		next(store, action)
 		print("State changed to:", prettyPrint(store:getState()))
 	end
 end

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -30,18 +30,16 @@ local function prettyPrint(t, indent)
 	return table.concat(outputBuffer, "")
 end
 
-local loggerPlugin = {}
--- Allows the output function to be changed at runtime.
-loggerPlugin.outputFunction = print
+local function loggerMiddleware(outputFunction)
+	outputFunction = outputFunction or print
 
-setmetatable(loggerPlugin, {
-	__call = function(_, next)
+	return function(next)
 		return function(store, action)
-			loggerPlugin.outputFunction("Action dispatched: "..prettyPrint(action))
+			outputFunction("Action dispatched: "..prettyPrint(action))
 			next(store, action)
-			loggerPlugin.outputFunction("State changed to:"..prettyPrint(store:getState()))
+			outputFunction("State changed to:"..prettyPrint(store:getState()))
 		end
 	end
-})
+end
 
-return loggerPlugin
+return loggerMiddleware

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -35,9 +35,10 @@ local function loggerMiddleware(outputFunction)
 
 	return function(next)
 		return function(store, action)
-			outputFunction("Action dispatched: " .. prettyPrint(action))
 			next(store, action)
-			outputFunction("State changed to: " .. prettyPrint(store:getState()))
+			outputFunction(("Action dispatched: %s\nState changed to: %s"):format(
+				prettyPrint(action),
+				prettyPrint(store:getState())))
 		end
 	end
 end

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -1,0 +1,41 @@
+local indentStr = "    "
+
+local function prettyPrint(t, indent)
+	indent = indent or 1
+	local outputBuffer = {
+		"{\n"
+	}
+
+	for key, value in pairs(t) do
+		local strKey = tostring(key)
+
+		table.insert(outputBuffer, indentStr:rep(indent + 1))
+		table.insert(outputBuffer, strKey)
+		table.insert(outputBuffer, " = ")
+
+		if type(value) == "table" then
+			table.insert(outputBuffer, prettyPrint(value, indent + 1))
+			table.insert(outputBuffer, "\n")
+		else
+			table.insert(outputBuffer, tostring(value))
+			table.insert(outputBuffer, "; (")
+			table.insert(outputBuffer, typeof(value))
+			table.insert(outputBuffer, ")\n")
+		end
+	end
+
+	table.insert(outputBuffer, indentStr:rep(indent))
+	table.insert(outputBuffer, "}")
+
+	return table.concat(outputBuffer, "")
+end
+
+local function loggerPlugin(next)
+	return function(store, action)
+		print("Action dispatched:", prettyPrint(action))
+		next(action)
+		print("State changed to:", prettyPrint(store:getState()))
+	end
+end
+
+return loggerPlugin

--- a/lib/loggerMiddleware.spec.lua
+++ b/lib/loggerMiddleware.spec.lua
@@ -13,13 +13,12 @@ return function()
 			outputCount = outputCount + 1
 		end
 
-		-- Modify the output function so we don't spam test logs.
-		loggerMiddleware.outputFunction = outputFunction
+		local logger = loggerMiddleware(outputFunction)
 
 		local store = Store.new(reducer, {
 			value = 0,
 			otherValue = {},
-		}, { loggerMiddleware })
+		}, { logger })
 		store:dispatch({
 			type = "test"
 		})

--- a/lib/loggerMiddleware.spec.lua
+++ b/lib/loggerMiddleware.spec.lua
@@ -23,6 +23,6 @@ return function()
 			type = "test"
 		})
 
-		expect(outputCount == 1).to.equal(true)
+		expect(outputCount >= 1).to.equal(true)
 	end)
 end

--- a/lib/loggerMiddleware.spec.lua
+++ b/lib/loggerMiddleware.spec.lua
@@ -23,6 +23,6 @@ return function()
 			type = "test"
 		})
 
-		expect(outputCount >= 1).to.equal(true)
+		expect(outputCount).to.equal(1)
 	end)
 end

--- a/lib/loggerMiddleware.spec.lua
+++ b/lib/loggerMiddleware.spec.lua
@@ -1,0 +1,29 @@
+return function()
+	local Store = require(script.Parent.Store)
+	local loggerMiddleware = require(script.Parent.loggerMiddleware)
+
+	it("should print whenever an action is dispatched", function()
+		local outputCount = 0
+
+		local function reducer(state, action)
+			return state
+		end
+
+		local function outputFunction()
+			outputCount = outputCount + 1
+		end
+
+		-- Modify the output function so we don't spam test logs.
+		loggerMiddleware.outputFunction = outputFunction
+
+		local store = Store.new(reducer, {
+			value = 0,
+			otherValue = {},
+		}, { loggerMiddleware })
+		store:dispatch({
+			type = "test"
+		})
+
+		expect(outputCount >= 1).to.be.ok()
+	end)
+end

--- a/lib/loggerMiddleware.spec.lua
+++ b/lib/loggerMiddleware.spec.lua
@@ -23,6 +23,6 @@ return function()
 			type = "test"
 		})
 
-		expect(outputCount >= 1).to.be.ok()
+		expect(outputCount == 1).to.equal(true)
 	end)
 end


### PR DESCRIPTION
This fixes #5. I wanted to open this to allow code reviews.

TODO:
- [x] Unit tests
- [x] Built-in logging middleware, as a combination example/debugging tool
- [x] Should middlewares affect the store initialization action? (ref. #12)
- [x] Make middlewares optional

Copy-pasted from my issue comment:

The API now:
```diff
- function Store.new(reducer, initialState)
+ function Store.new(reducer, initialState, middlewares)
```

Middlewares are applied left-to-right order - the rightmost middleware is invoked first.

Middlewares look like this:

```lua
local function loggerMiddleware(next)
    return function(store, action)
        print("action dispatched:", action.type)
        next(action)
        print("new state:")
        printTable(store:getState())
    end
end
```

Using this looks like:

```lua
local store = Store.new(reducer, initialState, { loggerMiddleware })
store:dispatch({
    type = "someAction",
    ...
})
-- prints "action dispatched: someAction"
-- then the new state
```