### PR TITLE
Make combineReducers not throw when initialState is nil

### DIFF
--- a/lib/combineReducers.lua
+++ b/lib/combineReducers.lua
@@ -3,6 +3,11 @@
 ]]
 local function combineReducers(map)
 	return function(state, action)
+		-- If state is nil, substitute it with a blank table.
+		if state == nil then
+			state = {}
+		end
+
 		local newState = {}
 
 		for key, reducer in pairs(map) do

--- a/lib/combineReducers.spec.lua
+++ b/lib/combineReducers.spec.lua
@@ -34,4 +34,19 @@ return function()
 		expect(newState.a).to.equal(1)
 		expect(newState.b).to.equal(3)
 	end)
+
+	it("should not throw when state is nil", function()
+		local reducer = combineReducers({
+			a = function(state, action)
+				return (state or 0) + 1
+			end,
+			b = function(state, action)
+				return (state or 0) + 3
+			end,
+		})
+
+		expect(function()
+			reducer(nil, {})
+		end).to.never.throw()
+	end)
 end


### PR DESCRIPTION
Thanks @vocksel for reporting this! `combineReducers` throws when you create a store and do not specify the initial state, because it tries to index into a nil value. This patch fixes this, and adds a test to catch future issues.