### PR TITLE
Introduce new middleware API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Rodux Changelog
 
 ## Current master
-* No changes
+* Added `combineReducers` utility, mirroring Redux's ([#9](https://github.com/Roblox/rodux/pull/9))
+* Added `createReducer` utility, similar to `redux-create-reducer` ([#10](https://github.com/Roblox/rodux/pull/10))
+* `type` is now required as a field on all actions
+* Introduced middleware ([#13](https://github.com/Roblox/rodux/pull/13))
+	* Thunks are no longer enabled by default, use `Rodux.thunkMiddleware` to add them back.
+	* Added `Rodux.loggerMiddleware` as a simple debugger
+	* The middleware API changed in [#29](https://github.com/Roblox/rodux/pull/29) in a backwards-incompatible way!
+* Errors thrown in `changed` event now have correct stack traces ([#27](https://github.com/Roblox/rodux/pull/27))
 
-## 1.0.0 (TODO: Date)
-* Initial release
+## Public Release (December 13, 2017)
+* Initial release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 	* Thunks are no longer enabled by default, use `Rodux.thunkMiddleware` to add them back.
 	* Added `Rodux.loggerMiddleware` as a simple debugger
 	* The middleware API changed in [#29](https://github.com/Roblox/rodux/pull/29) in a backwards-incompatible way!
+		* Middleware now run left-to-right instead of right-to-left!
 * Errors thrown in `changed` event now have correct stack traces ([#27](https://github.com/Roblox/rodux/pull/27))
 
 ## Public Release (December 13, 2017)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -153,7 +153,7 @@ local reducer = createReducer(initialState, {
 ```
 
 ## Middleware
-Rodux provides an API that allows changing the way that actions are dispatched called *middleware*. To attach middlewares to a store, pass a list of middleware as the third argument to `Store.new`.
+Rodux provides an API that allows changing the way that actions are dispatched called *middleware*. To attach middleware to a store, pass a list of middleware as the third argument to `Store.new`.
 
 !!! warn
 	The middleware API changed in [#29](https://github.com/Roblox/rodux/pull/29) -- middleware written against the old API will not work!
@@ -179,6 +179,14 @@ end
 ```
 
 Rodux also ships with several middleware that address common use-cases.
+
+To apply middleware, pass a list of middleware as the third argument to `Store.new`:
+
+```lua
+local store = Store.new(reducer, initialState, { simpleLogger })
+```
+
+Middleware runs from left to right when an action is dispatched. That means that if a middleware does not call `nextDispatch` when handling an action, any middleware after it will not run.
 
 ### Rodux.loggerMiddleware
 A middleware that logs actions and the new state that results from them.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -164,7 +164,7 @@ A single middleware is just a function with the following signature:
 (nextDispatch, store) -> (action) -> result
 ```
 
-That is, middleware is a function that accepts the next middleware to apply and returns a new function. That function takes the `Store` and the current action and can dispatch more actions, log to output, or do network requests!
+A middleware is a function that accepts the next dispatch function in the *middleware chain*, as well as the store the middleware is being used with, and returns a new function. That function is called whenever an action is dispatched and can dispatch more actions, log to output, or perform any side effects!
 
 A simple version of Rodux's `loggerMiddleware` is as easy as:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -155,10 +155,13 @@ local reducer = createReducer(initialState, {
 ## Middleware
 Rodux provides an API that allows changing the way that actions are dispatched called *middleware*. To attach middlewares to a store, pass a list of middleware as the third argument to `Store.new`.
 
+!!! warn
+	The middleware API changed in [#29](https://github.com/Roblox/rodux/pull/29) -- middleware written against the old API will not work!
+
 A single middleware is just a function with the following signature:
 
 ```
-(next) -> (store, action) -> result
+(nextDispatch, store) -> (action) -> result
 ```
 
 That is, middleware is a function that accepts the next middleware to apply and returns a new function. That function takes the `Store` and the current action and can dispatch more actions, log to output, or do network requests!
@@ -166,11 +169,11 @@ That is, middleware is a function that accepts the next middleware to apply and 
 A simple version of Rodux's `loggerMiddleware` is as easy as:
 
 ```lua
-local function simpleLogger(next)
-	return function(store, action)
+local function simpleLogger(nextDispatch, store)
+	return function(action)
 		print("Dispatched action of type", action.type)
 
-		return next(store, action)
+		return nextDispatch(action)
 	end
 end
 ```

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -48,12 +48,17 @@ function Store.new(reducer, initialState, middlewares)
 	table.insert(self._connections, connection)
 
 	if middlewares then
-		local dispatch = Store.dispatch
-		for _, middleware in ipairs(middlewares) do
-			dispatch = middleware(dispatch)
+		local dispatch = function(...)
+			return self:dispatch(...)
 		end
 
-		self.dispatch = dispatch
+		for _, middleware in ipairs(middlewares) do
+			dispatch = middleware(dispatch, self)
+		end
+
+		self.dispatch = function(self, ...)
+			return dispatch(...)
+		end
 	end
 
 	return self

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -53,7 +53,8 @@ function Store.new(reducer, initialState, middlewares)
 			return unboundDispatch(self, ...)
 		end
 
-		for _, middleware in ipairs(middlewares) do
+		for i = #middlewares, 1, -1 do
+			local middleware = middlewares[i]
 			dispatch = middleware(dispatch, self)
 		end
 

--- a/lib/Store.lua
+++ b/lib/Store.lua
@@ -48,8 +48,9 @@ function Store.new(reducer, initialState, middlewares)
 	table.insert(self._connections, connection)
 
 	if middlewares then
+		local unboundDispatch = self.dispatch
 		local dispatch = function(...)
-			return self:dispatch(...)
+			return unboundDispatch(self, ...)
 		end
 
 		for _, middleware in ipairs(middlewares) do

--- a/lib/loggerMiddleware.lua
+++ b/lib/loggerMiddleware.lua
@@ -39,9 +39,9 @@ local loggerMiddleware = {
 	outputFunction = print,
 }
 
-function loggerMiddleware.middleware(next)
-	return function(store, action)
-		local result = next(store, action)
+function loggerMiddleware.middleware(nextDispatch, store)
+	return function(action)
+		local result = nextDispatch(action)
 
 		loggerMiddleware.outputFunction(("Action dispatched: %s\nState changed to: %s"):format(
 			prettyPrint(action),

--- a/lib/thunkMiddleware.lua
+++ b/lib/thunkMiddleware.lua
@@ -4,12 +4,12 @@
 	This middleware consumes the function; middleware further down the chain
 	will not receive it.
 ]]
-local function thunkMiddleware(next)
-	return function(store, action)
+local function thunkMiddleware(nextDispatch, store)
+	return function(action)
 		if typeof(action) == "function" then
 			return action(store)
 		else
-			return next(store, action)
+			return nextDispatch(action)
 		end
 	end
 end


### PR DESCRIPTION
This changes the middleware signature and makes it line up more closely with Redux. It solves a problem we hit of not being able to get the store's state until an action was dispatched.

It also reverses the order that middleware runs in to be left-to-right. Previously, it was right-to-left and a lot of people were really confused, including us. Now people *should be* less confused, and we can use more precise language to describe middleware execution order.

**This is a breaking change.**

Old signature:
```
(nextDispatch) => (store, action) => any
```

New signature:
```
(nextDispatch, store) => (action) => any
```

In addition, the `nextDispatch` function (previously called `next`, which collided with Lua's standard library) no longer accepts the store as the first argument, ie it is bound to the store instance.

TODO:
* [x] CHANGELOG
* [x] Tests
* [x] Docs