### PR TITLE
Fix createReducer initialState logic

### DIFF
--- a/lib/createReducer.lua
+++ b/lib/createReducer.lua
@@ -1,7 +1,7 @@
 return function(initialState, handlers)
 	return function(state, action)
 		if state == nil then
-			return initialState
+			state = initialState
 		end
 
 		local handler = handlers[action.type]


### PR DESCRIPTION
Right now, action handlers aren't run at all if `initialState` is nil. This isn't how we want `createReducers` to work I think, since it means you can't have nil as a state for your reducer!

This is a small fix to fix that.

Checklist before merge:
* [ ] Update tests
* [ ] Changelog entry