### PR TITLE
Update manifest

### DIFF
--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,3 +1,4 @@
+[package]
 name = "Rodux"
 author = "Roblox"
 license = "Apache-2.0"

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,6 +1,6 @@
 [package]
-name = "Rodux"
+name = "roblox/rodux"
 author = "Roblox"
 license = "Apache-2.0"
 content_root = "lib"
-version = "0.1.0"
+version = "1.0.0"


### PR DESCRIPTION
Once this change goes in, we can cut a 1.0.0. Rodux has been stable for a while, so it'll be good to have a non-pre-release release!