### PR TITLE
Dark mode for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rodux Changelog
 
+## Unreleased Changes
+* Added color schemes for documentation based on user preference ([#56](https://github.com/Roblox/rodux/pull/56)).
+
 ## 1.0.0 (2019-09-18)
 * Added `combineReducers` utility, mirroring Redux's ([#9](https://github.com/Roblox/rodux/pull/9))
 * Added `createReducer` utility, similar to `redux-create-reducer` ([#10](https://github.com/Roblox/rodux/pull/10))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ theme:
   palette:
     primary: 'Light Blue'
     accent: 'Light Blue'
+    scheme: preference
 
 pages:
   - Home: index.md


### PR DESCRIPTION
Redux's documentation is a health hazard. I believe I'm suffering from eye fatigue looking at the bright white colors.

This will acknowledge any health concerns as well as provide a seamless reading experience.

Checklist before submitting:
* [X] Added entry to `CHANGELOG.md`
* [X] Added/updated relevant tests
* [X] Added/updated documentation