### PR TITLE
Better following of the Roblox Luau style guide.

### DIFF
--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -6,15 +6,16 @@
 ]]
 
 local function immutableAppend(list, ...)
-	local new = {}
 	local len = #list
+	local varLen = select("#", ...)
+	local new = table.create(len + varLen)
 
-	for key = 1, len do
-		new[key] = list[key]
+	for index, value in ipairs(list) do
+		new[index] = value
 	end
 
-	for i = 1, select("#", ...) do
-		new[len + i] = select(i, ...)
+	for index = 1, varLen do
+		new[len + index] = select(index, ...)
 	end
 
 	return new
@@ -23,9 +24,9 @@ end
 local function immutableRemoveValue(list, removeValue)
 	local new = {}
 
-	for i = 1, #list do
-		if list[i] ~= removeValue then
-			table.insert(new, list[i])
+	for _, value in ipairs(list) do
+		if value ~= removeValue then
+			table.insert(new, value)
 		end
 	end
 
@@ -33,12 +34,11 @@ local function immutableRemoveValue(list, removeValue)
 end
 
 local Signal = {}
-
 Signal.__index = Signal
 
 function Signal.new()
 	local self = {
-		_listeners = {}
+		_listeners = {},
 	}
 
 	setmetatable(self, Signal)
@@ -60,7 +60,7 @@ function Signal:connect(callback)
 	end
 
 	return {
-		disconnect = disconnect
+		disconnect = disconnect,
 	}
 end
 

--- a/src/Store.lua
+++ b/src/Store.lua
@@ -58,7 +58,7 @@ function Store.new(reducer, initialState, middlewares)
 			dispatch = middleware(dispatch, self)
 		end
 
-		self.dispatch = function(self, ...)
+		self.dispatch = function(_, ...)
 			return dispatch(...)
 		end
 	end
@@ -89,7 +89,7 @@ function Store:dispatch(action)
 		self._state = self._reducer(self._state, action)
 		self._mutatedSinceFlush = true
 	else
-		error(("actions of type %q are not permitted"):format(typeof(action)), 2)
+		error(string.format("actions of type %q are not permitted", typeof(action)), 2)
 	end
 end
 

--- a/src/loggerMiddleware.lua
+++ b/src/loggerMiddleware.lua
@@ -28,7 +28,7 @@ local function prettyPrint(value, indentLevel)
 		table.insert(output, ")")
 	end
 
-	return table.concat(output, "")
+	return table.concat(output)
 end
 
 -- We want to be able to override outputFunction in tests, so the shape of this

--- a/src/loggerMiddleware.lua
+++ b/src/loggerMiddleware.lua
@@ -7,16 +7,16 @@ local function prettyPrint(value, indentLevel)
 	if typeof(value) == "table" then
 		table.insert(output, "{\n")
 
-		for key, value in pairs(value) do
-			table.insert(output, indent:rep(indentLevel + 1))
+		for key, subValue in pairs(value) do
+			table.insert(output, string.rep(indent, indentLevel + 1))
 			table.insert(output, tostring(key))
 			table.insert(output, " = ")
 
-			table.insert(output, prettyPrint(value, indentLevel + 1))
+			table.insert(output, prettyPrint(subValue, indentLevel + 1))
 			table.insert(output, "\n")
 		end
 
-		table.insert(output, indent:rep(indentLevel))
+		table.insert(output, string.rep(indent, indentLevel))
 		table.insert(output, "}")
 	elseif typeof(value) == "string" then
 		table.insert(output, string.format("%q", value))
@@ -43,7 +43,8 @@ function loggerMiddleware.middleware(nextDispatch, store)
 	return function(action)
 		local result = nextDispatch(action)
 
-		loggerMiddleware.outputFunction(("Action dispatched: %s\nState changed to: %s"):format(
+		loggerMiddleware.outputFunction(string.format(
+			"Action dispatched: %s\nState changed to: %s",
 			prettyPrint(action),
 			prettyPrint(store:getState())
 		))

--- a/src/loggerMiddleware.spec.lua
+++ b/src/loggerMiddleware.spec.lua
@@ -6,7 +6,7 @@ return function()
 		local outputCount = 0
 		local outputMessage
 
-		local function reducer(state, action)
+		local function reducer(state)
 			return state
 		end
 

--- a/src/makeActionCreator.lua
+++ b/src/makeActionCreator.lua
@@ -1,23 +1,21 @@
 --[[
 	A helper function to define a Rodux action creator with an associated name.
 ]]
-local function makeActionCreator(name, fn)
+local function makeActionCreator(name, callback)
 	assert(type(name) == "string", "Bad argument #1: Expected a string name for the action creator")
-
-	assert(type(fn) == "function", "Bad argument #2: Expected a function that creates action objects")
+	assert(type(callback) == "function", "Bad argument #2: Expected a function that creates action objects")
 
 	return setmetatable({
 		name = name,
 	}, {
-		__call = function(self, ...)
-			local result = fn(...)
-
+		__call = function(_, ...)
+			local result = callback(...)
 			assert(type(result) == "table", "Invalid action: An action creator must return a table")
 
 			result.type = name
 
 			return result
-		end
+		end,
 	})
 end
 


### PR DESCRIPTION
I fixed a few things that weren't inline with the [Roblox Lua Style Guide](https://roblox.github.io/lua-style-guide/), namely trailing commas. I also changed some things to better match what was suggested in the [Luau performance section](https://roblox.github.io/luau/performance.html), such as using the iterator functions and using `string.x` versus `:x`.