### PR TITLE
Add extra argument to thunk middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rodux Changelog
 
 ## Unreleased Changes
+* Add makeThunkMiddleware to inject custom argument ([#69](https://github.com/Roblox/rodux/pull/69)).
 
 ## 3.0.0 (2021-03-25)
 * Revise error reporting logic; restore default semantics from version 1.x ([#61](https://github.com/Roblox/rodux/pull/61)).

--- a/docs/advanced/thunks.md
+++ b/docs/advanced/thunks.md
@@ -29,3 +29,28 @@ end)
 ```
 
 Thunks are a simple way to introduce more complex processing of `action` objects, but you may want to consider creating custom [`middleware`](middleware.md) for complex features instead of relying on thunks alone.
+
+It is also possible to inject a custom argument into the thunk middleware. This is useful for cases like using an API service layer that could be swapped out for a mock service in tests. This is accomplished by using the `Rodux.makeThunkMiddleware` API instead:
+
+```lua
+local myThunkMiddleware = Rodux.makeThunkMiddleware(myCustomArg)
+local store = Rodux.Store.new(reducer, initialState, {
+	myThunkMiddleware,
+})
+
+store:dispatch(function(store, myCustomArg)
+	print("Hello from a thunk with extra argument:", myCustomArg)
+	store:dispatch({
+		type = "thunkAction"
+	})
+end)
+```
+
+If multiple values need to be passed in, they can be combined into a single table:
+
+```lua
+local myThunkMiddleware = Rodux.makeThunkMiddleware({
+    [RoactNetworking] = networking,
+    AvatarEditorService = AvatarEditorService,
+})
+```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -263,3 +263,27 @@ store:dispatch(function(store)
 	})
 end)
 ```
+
+It is also possible to inject a custom argument into the thunk middleware. This is useful for cases like using an API service layer that could be swapped out for a mock service in tests. This is accomplished by using the `Rodux.makeThunkMiddleware` API instead:
+
+```lua
+local myThunkMiddleware = Rodux.makeThunkMiddleware(myCustomArg)
+local store = Store.new(reducer, initialState, { myThunkMiddleware })
+
+store:dispatch(function(store, myCustomArg)
+	print("Hello from a thunk with extra argument:", myCustomArg)
+
+	store:dispatch({
+		type = "thunkAction"
+	})
+end)
+```
+
+If multiple values need to be passed in, they can be combined into a single table:
+
+```lua
+local myThunkMiddleware = Rodux.makeThunkMiddleware({
+    [RoactNetworking] = networking,
+    AvatarEditorService = AvatarEditorService,
+})
+```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -264,7 +264,12 @@ store:dispatch(function(store)
 end)
 ```
 
-It is also possible to inject a custom argument into the thunk middleware. This is useful for cases like using an API service layer that could be swapped out for a mock service in tests. This is accomplished by using the `Rodux.makeThunkMiddleware` API instead:
+### Rodux.makeThunkMiddleware (unreleased)
+```
+Rodux.makeThunkMiddleware(extraArgument) -> thunkMiddleware
+```
+
+A function that creates a thunk middleware that injects a custom argument when invoking thunks (in addition to the store itself). This is useful for cases like using an API service layer that could be swapped out for a mock service in tests.
 
 ```lua
 local myThunkMiddleware = Rodux.makeThunkMiddleware(myCustomArg)
@@ -277,13 +282,4 @@ store:dispatch(function(store, myCustomArg)
 		type = "thunkAction"
 	})
 end)
-```
-
-If multiple values need to be passed in, they can be combined into a single table:
-
-```lua
-local myThunkMiddleware = Rodux.makeThunkMiddleware({
-    [RoactNetworking] = networking,
-    AvatarEditorService = AvatarEditorService,
-})
 ```

--- a/src/init.lua
+++ b/src/init.lua
@@ -4,6 +4,7 @@ local combineReducers = require(script.combineReducers)
 local makeActionCreator = require(script.makeActionCreator)
 local loggerMiddleware = require(script.loggerMiddleware)
 local thunkMiddleware = require(script.thunkMiddleware)
+local makeThunkMiddleware = require(script.makeThunkMiddleware)
 
 return {
 	Store = Store,
@@ -12,4 +13,5 @@ return {
 	makeActionCreator = makeActionCreator,
 	loggerMiddleware = loggerMiddleware.middleware,
 	thunkMiddleware = thunkMiddleware,
+	makeThunkMiddleware = makeThunkMiddleware,
 }

--- a/src/makeThunkMiddleware.lua
+++ b/src/makeThunkMiddleware.lua
@@ -1,0 +1,40 @@
+--[[
+	A middleware that allows for functions to be dispatched with an extra
+	argument for convenience. Functions will receive two arguments:
+	the store itself and the extra argument provided initially to makeThunkMiddleware.
+
+	This middleware consumes the function; middleware further down the chain
+	will not receive it.
+]]
+local function tracebackReporter(message)
+	return debug.traceback(message)
+end
+
+local function makeThunkMiddleware(extraArgument)
+	local function thunkMiddleware(nextDispatch, store)
+		return function(action)
+			if typeof(action) == "function" then
+				local ok, result = xpcall(function()
+					return action(store, extraArgument)
+				end, tracebackReporter)
+
+				if not ok then
+					-- report the error and move on so it's non-fatal app
+					store._errorReporter.reportReducerError(store:getState(), action, {
+						message = "Caught error in thunk",
+						thrownValue = result,
+					})
+					return nil
+				end
+
+				return result
+			end
+
+			return nextDispatch(action)
+		end
+	end
+
+	return thunkMiddleware
+end
+
+return makeThunkMiddleware

--- a/src/makeThunkMiddleware.lua
+++ b/src/makeThunkMiddleware.lua
@@ -11,7 +11,6 @@ local function tracebackReporter(message)
 end
 
 local function makeThunkMiddleware(extraArgument)
-	print("extraArgument:", extraArgument)
 	local function thunkMiddleware(nextDispatch, store)
 		return function(action)
 			if typeof(action) == "function" then

--- a/src/makeThunkMiddleware.lua
+++ b/src/makeThunkMiddleware.lua
@@ -11,6 +11,7 @@ local function tracebackReporter(message)
 end
 
 local function makeThunkMiddleware(extraArgument)
+	print("extraArgument:", extraArgument)
 	local function thunkMiddleware(nextDispatch, store)
 		return function(action)
 			if typeof(action) == "function" then

--- a/src/thunkMiddleware.lua
+++ b/src/thunkMiddleware.lua
@@ -4,31 +4,6 @@
 	This middleware consumes the function; middleware further down the chain
 	will not receive it.
 ]]
-local function tracebackReporter(message)
-	return debug.traceback(message)
-end
+local makeThunkMiddleware = require(script.Parent.makeThunkMiddleware)
 
-local function thunkMiddleware(nextDispatch, store)
-	return function(action)
-		if typeof(action) == "function" then
-			local ok, result = xpcall(function()
-				return action(store)
-			end, tracebackReporter)
-
-			if not ok then
-				-- report the error and move on so it's non-fatal app
-				store._errorReporter.reportReducerError(store:getState(), action, {
-					message = "Caught error in thunk",
-					thrownValue = result,
-				})
-				return nil
-			end
-
-			return result
-		end
-
-		return nextDispatch(action)
-	end
-end
-
-return thunkMiddleware
+return makeThunkMiddleware(nil) -- no extra argument

--- a/src/thunkMiddleware.spec.lua
+++ b/src/thunkMiddleware.spec.lua
@@ -127,17 +127,16 @@ return function()
 		local myExtraArg = { What = "MyExtraArg" }
 		local store = Store.new(reducer, {}, { makeThunkMiddleware(myExtraArg) })
 		local thunkCount = 0
-		local receivedExtraArg = nil
+		local extraArgParam = nil
 
 		local function thunk(_store, extraArg)
-			print("thunk invoked with extraArg:", extraArg)
 			thunkCount = thunkCount + 1
-			receivedExtraArg = extraArg
+			extraArgParam = extraArg
 		end
 
 		store:dispatch(thunk)
 
 		expect(thunkCount).to.equal(1)
-		expect(recievedExtraArg).to.equal(myExtraArg)
+		expect(extraArgParam).to.equal(myExtraArg)
 	end)
 end

--- a/src/thunkMiddleware.spec.lua
+++ b/src/thunkMiddleware.spec.lua
@@ -130,6 +130,7 @@ return function()
 		local receivedExtraArg = nil
 
 		local function thunk(_store, extraArg)
+			print("thunk invoked with extraArg:", extraArg)
 			thunkCount = thunkCount + 1
 			receivedExtraArg = extraArg
 		end

--- a/src/thunkMiddleware.spec.lua
+++ b/src/thunkMiddleware.spec.lua
@@ -1,6 +1,7 @@
 return function()
 	local Store = require(script.Parent.Store)
 	local thunkMiddleware = require(script.Parent.thunkMiddleware)
+	local makeThunkMiddleware = require(script.Parent.makeThunkMiddleware)
 
 	it("should dispatch thunks", function()
 		local function reducer(state, action)

--- a/src/thunkMiddleware.spec.lua
+++ b/src/thunkMiddleware.spec.lua
@@ -117,4 +117,25 @@ return function()
 		store:dispatch(safeThunk)
 		expect(ranSafeThunk).to.equal(true)
 	end)
+
+	it("should send extra argument to thunks when provided", function()
+		local function reducer(state, action)
+			return state
+		end
+
+		local myExtraArg = { What = "MyExtraArg" }
+		local store = Store.new(reducer, {}, { makeThunkMiddleware(myExtraArg) })
+		local thunkCount = 0
+		local receivedExtraArg = nil
+
+		local function thunk(_store, extraArg)
+			thunkCount = thunkCount + 1
+			receivedExtraArg = extraArg
+		end
+
+		store:dispatch(thunk)
+
+		expect(thunkCount).to.equal(1)
+		expect(recievedExtraArg).to.equal(myExtraArg)
+	end)
 end


### PR DESCRIPTION
This feature is equivalent to what is available in newer versions of Redux:
https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument

It allows arbitrary parameters to injected into thunks via a table passed in at Rodux initialization time (useful for passing in services or anything else we might want to mock for tests).

It can replace other custom middlewares we've written to achieve the same thing (e.g. PaginatedFetchThunk.middleware, AvatarEditorServiceThunk.middleware, RNAdapterThunk.middleware)