### PR TITLE
Add Luau types for actions and reducers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,10 @@ jobs:
         version: "^1.0.1"
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: code quality (stylua)
+    - name: code quality
       shell: bash
       run: |
+        selene src
         stylua -c src/
 
     - name: install and run darklua
@@ -50,11 +51,6 @@ jobs:
       run: |
         lua -lluacov test/lemur.lua
         luacov -r lcov
-
-    - name: code quality (selene)
-      shell: bash
-      run: |
-        selene src
 
     - name: Report to Coveralls
       uses: coverallsapp/github-action@1.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
         version: "^1.0.1"
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: code quality (stylua)
+      shell: bash
+      run: |
+        stylua -c src/
+
     - name: install and run darklua
       run: |
         cargo install --git https://gitlab.com/seaofvoices/darklua.git#v0.6.0
@@ -46,11 +51,10 @@ jobs:
         lua -lluacov test/lemur.lua
         luacov -r lcov
 
-    - name: code quality
+    - name: code quality (selene)
       shell: bash
       run: |
         selene src
-        stylua -c src/
 
     - name: Report to Coveralls
       uses: coverallsapp/github-action@1.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 * Add makeThunkMiddleware to inject custom argument ([#69](https://github.com/Roblox/rodux/pull/69)).
+* Add Luau types for actions and reducers ([#70](https://github.com/Roblox/rodux/pull/70)).
 
 ## 3.0.0 (2021-03-25)
 * Revise error reporting logic; restore default semantics from version 1.x ([#61](https://github.com/Roblox/rodux/pull/61)).

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "6.2.0" }
 selene = { source = "Kampfkarren/selene", version = "0.14" }
-stylua = { source = "JohnnyMorganz/StyLua", version = "0.11" }
+stylua = { source = "JohnnyMorganz/StyLua", version = "0.13.1" }

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "6.2.0" }
-selene = { source = "Kampfkarren/selene", version = "0.14" }
+selene = { source = "Kampfkarren/selene", version = "0.18.1" }
 stylua = { source = "JohnnyMorganz/StyLua", version = "0.13.1" }

--- a/src/combineReducers.lua
+++ b/src/combineReducers.lua
@@ -4,13 +4,17 @@
 
 local actions = require(script.Parent.types.actions)
 local reducers = require(script.Parent.types.reducers)
+local store = require(script.Parent.types.store)
 
 type AnyAction = actions.AnyAction
 
 export type Reducer<State = any, Action = AnyAction> = reducers.Reducer<State, Action>
 export type ReducersMapObject<State = any, Action = AnyAction> = reducers.ReducersMapObject<State, Action>
 
-local function combineReducers<State>(map: ReducersMapObject): Reducer<State>
+type CombinedState<State> = store.CombinedState<State>
+
+local function combineReducers<State>(map: ReducersMapObject): Reducer<CombinedState<State>>
+	-- FIXME LUAU: Remove any cast here once we can constrain the generic type State to a table type
 	return function(state, action)
 		-- If state is nil, substitute it with a blank table.
 		if state == nil then

--- a/src/combineReducers.lua
+++ b/src/combineReducers.lua
@@ -1,22 +1,32 @@
 --[[
 	Create a composite reducer from a map of keys and sub-reducers.
 ]]
-local function combineReducers(map)
-	return function(state, action)
-		-- If state is nil, substitute it with a blank table.
-		if state == nil then
-			state = {}
-		end
 
-		local newState = {}
+local _actions = require(script.Parent.types.actions)
+local _reducers = require(script.Parent.types.reducers)
 
-		for key, reducer in pairs(map) do
-			-- Each reducer gets its own state, not the entire state table
-			newState[key] = reducer(state[key], action)
-		end
+type AnyAction = _actions.AnyAction
 
-		return newState
-	end
+export type Reducer<State = any, Action = AnyAction> = _reducers.Reducer<State, Action>
+
+local function combineReducers<State>(map): Reducer<State>
+	return (
+		function(state, action)
+			-- If state is nil, substitute it with a blank table.
+			if state == nil then
+				state = {}
+			end
+
+			local newState = {}
+
+			for key, reducer in pairs(map) do
+				-- Each reducer gets its own state, not the entire state table
+				newState[key] = reducer(state[key], action)
+			end
+
+			return newState
+		end :: any
+	) :: Reducer<State>
 end
 
 return combineReducers

--- a/src/combineReducers.lua
+++ b/src/combineReducers.lua
@@ -8,25 +8,24 @@ local reducers = require(script.Parent.types.reducers)
 type AnyAction = actions.AnyAction
 
 export type Reducer<State = any, Action = AnyAction> = reducers.Reducer<State, Action>
+export type ReducersMapObject<State = any, Action = AnyAction> = reducers.ReducersMapObject<State, Action>
 
-local function combineReducers<State>(map): Reducer<State>
-	return (
-		function(state, action)
-			-- If state is nil, substitute it with a blank table.
-			if state == nil then
-				state = {}
-			end
+local function combineReducers<State>(map: ReducersMapObject): Reducer<State>
+	return function(state, action)
+		-- If state is nil, substitute it with a blank table.
+		if state == nil then
+			state = {}
+		end
 
-			local newState = {}
+		local newState = {}
 
-			for key, reducer in pairs(map) do
-				-- Each reducer gets its own state, not the entire state table
-				newState[key] = reducer(state[key], action)
-			end
+		for key, reducer in pairs(map) do
+			-- Each reducer gets its own state, not the entire state table
+			newState[key] = reducer(state[key], action)
+		end
 
-			return newState
-		end :: any
-	) :: Reducer<State>
+		return newState
+	end :: any
 end
 
 return combineReducers

--- a/src/combineReducers.lua
+++ b/src/combineReducers.lua
@@ -2,12 +2,12 @@
 	Create a composite reducer from a map of keys and sub-reducers.
 ]]
 
-local _actions = require(script.Parent.types.actions)
-local _reducers = require(script.Parent.types.reducers)
+local actions = require(script.Parent.types.actions)
+local reducers = require(script.Parent.types.reducers)
 
-type AnyAction = _actions.AnyAction
+type AnyAction = actions.AnyAction
 
-export type Reducer<State = any, Action = AnyAction> = _reducers.Reducer<State, Action>
+export type Reducer<State = any, Action = AnyAction> = reducers.Reducer<State, Action>
 
 local function combineReducers<State>(map): Reducer<State>
 	return (

--- a/src/createReducer.lua
+++ b/src/createReducer.lua
@@ -1,4 +1,11 @@
-return function(initialState, handlers)
+local _actions = require(script.Parent.types.actions)
+local _reducers = require(script.Parent.types.reducers)
+
+type AnyAction = _actions.AnyAction
+
+export type Reducer<State = any, Action = AnyAction> = _reducers.Reducer<State, Action>
+
+return function<State>(initialState, handlers): Reducer<State>
 	return function(state, action)
 		if state == nil then
 			state = initialState

--- a/src/createReducer.lua
+++ b/src/createReducer.lua
@@ -6,7 +6,8 @@ type AnyAction = actions.AnyAction
 export type Reducer<State = any, Action = AnyAction> = reducers.Reducer<State, Action>
 
 return function<State>(initialState, handlers): Reducer<State>
-	return function(state, action)
+	-- FIXME LUAU: Prefer any cast to avoid assert runtime overhead until typechecker can narrow type of _state_ to be non-nil
+	return function(state: any, action)
 		if state == nil then
 			state = initialState
 		end

--- a/src/createReducer.lua
+++ b/src/createReducer.lua
@@ -1,9 +1,9 @@
-local _actions = require(script.Parent.types.actions)
-local _reducers = require(script.Parent.types.reducers)
+local actions = require(script.Parent.types.actions)
+local reducers = require(script.Parent.types.reducers)
 
-type AnyAction = _actions.AnyAction
+type AnyAction = actions.AnyAction
 
-export type Reducer<State = any, Action = AnyAction> = _reducers.Reducer<State, Action>
+export type Reducer<State = any, Action = AnyAction> = reducers.Reducer<State, Action>
 
 return function<State>(initialState, handlers): Reducer<State>
 	return function(state, action)

--- a/src/init.lua
+++ b/src/init.lua
@@ -9,7 +9,7 @@ local makeThunkMiddleware = require(script.makeThunkMiddleware)
 local actions = require(script.types.actions)
 local reducers = require(script.types.reducers)
 
-export type Action<Type = string> = actions.Action<Type>
+export type Action<Type = any> = actions.Action<Type>
 export type AnyAction = actions.AnyAction
 export type ActionCreator<Type, Action, Args...> = actions.ActionCreator<Type, Action, Args...>
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -6,14 +6,14 @@ local loggerMiddleware = require(script.loggerMiddleware)
 local thunkMiddleware = require(script.thunkMiddleware)
 local makeThunkMiddleware = require(script.makeThunkMiddleware)
 
-local _actions = require(script.types.actions)
-local _reducers = require(script.types.reducers)
+local actions = require(script.types.actions)
+local reducers = require(script.types.reducers)
 
-export type Action<Type = any> = _actions.Action<Type>
-export type AnyAction = _actions.AnyAction
-export type ActionCreator<Type, Action, Args...> = _actions.ActionCreator<Type, Action, Args...>
+export type Action<Type = any> = actions.Action<Type>
+export type AnyAction = actions.AnyAction
+export type ActionCreator<Type, Action, Args...> = actions.ActionCreator<Type, Action, Args...>
 
-export type Reducer<State = any, Action = AnyAction> = _reducers.Reducer<State, Action>
+export type Reducer<State = any, Action = AnyAction> = reducers.Reducer<State, Action>
 
 return {
 	Store = Store,

--- a/src/init.lua
+++ b/src/init.lua
@@ -9,7 +9,7 @@ local makeThunkMiddleware = require(script.makeThunkMiddleware)
 local actions = require(script.types.actions)
 local reducers = require(script.types.reducers)
 
-export type Action<Type = any> = actions.Action<Type>
+export type Action<Type = string> = actions.Action<Type>
 export type AnyAction = actions.AnyAction
 export type ActionCreator<Type, Action, Args...> = actions.ActionCreator<Type, Action, Args...>
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -6,6 +6,15 @@ local loggerMiddleware = require(script.loggerMiddleware)
 local thunkMiddleware = require(script.thunkMiddleware)
 local makeThunkMiddleware = require(script.makeThunkMiddleware)
 
+local _actions = require(script.types.actions)
+local _reducers = require(script.types.reducers)
+
+export type Action<Type = any> = _actions.Action<Type>
+export type AnyAction = _actions.AnyAction
+export type ActionCreator<Type, Action, Args...> = _actions.ActionCreator<Type, Action, Args...>
+
+export type Reducer<State = any, Action = AnyAction> = _reducers.Reducer<State, Action>
+
 return {
 	Store = Store,
 	createReducer = createReducer,

--- a/src/makeActionCreator.lua
+++ b/src/makeActionCreator.lua
@@ -1,7 +1,15 @@
 --[[
 	A helper function to define a Rodux action creator with an associated name.
 ]]
-local function makeActionCreator(name, fn)
+
+local _actions = require(script.Parent.types.actions)
+
+export type ActionCreator<Type, Action, Args...> = _actions.ActionCreator<Type, Action, Args...>
+
+local function makeActionCreator<Type, Action, Args...>(
+	name: Type,
+	fn: (Args...) -> Action
+): ActionCreator<Type, Action, Args...>
 	assert(type(name) == "string", "Bad argument #1: Expected a string name for the action creator")
 
 	assert(type(fn) == "function", "Bad argument #2: Expected a function that creates action objects")
@@ -9,7 +17,7 @@ local function makeActionCreator(name, fn)
 	return setmetatable({
 		name = name,
 	}, {
-		__call = function(self, ...)
+		__call = function(_self, ...: Args...): Action & { type: Type }
 			local result = fn(...)
 
 			assert(type(result) == "table", "Invalid action: An action creator must return a table")

--- a/src/makeActionCreator.lua
+++ b/src/makeActionCreator.lua
@@ -17,7 +17,7 @@ local function makeActionCreator<Type, Action, Args...>(
 	return setmetatable({
 		name = name,
 	}, {
-		__call = function(_self, ...: Args...): Action & { type: Type }
+		__call = function(_self: any, ...: Args...): Action & { type: Type }
 			local result = fn(...)
 
 			assert(type(result) == "table", "Invalid action: An action creator must return a table")

--- a/src/makeActionCreator.lua
+++ b/src/makeActionCreator.lua
@@ -2,9 +2,9 @@
 	A helper function to define a Rodux action creator with an associated name.
 ]]
 
-local _actions = require(script.Parent.types.actions)
+local actions = require(script.Parent.types.actions)
 
-export type ActionCreator<Type, Action, Args...> = _actions.ActionCreator<Type, Action, Args...>
+export type ActionCreator<Type, Action, Args...> = actions.ActionCreator<Type, Action, Args...>
 
 local function makeActionCreator<Type, Action, Args...>(
 	name: Type,

--- a/src/types/actions.lua
+++ b/src/types/actions.lua
@@ -1,0 +1,14 @@
+export type Action<Type = any> = {
+	type: Type,
+}
+
+export type AnyAction = Action & {
+	[string]: any,
+}
+
+export type ActionCreator<Type, Action, Args...> = typeof(setmetatable(
+	{} :: { name: Type },
+	{} :: { __call: (any, Args...) -> (Action & { type: Type }) }
+))
+
+return nil

--- a/src/types/actions.lua
+++ b/src/types/actions.lua
@@ -1,4 +1,4 @@
-export type Action<Type = any> = {
+export type Action<Type = string> = {
 	type: Type,
 }
 

--- a/src/types/actions.lua
+++ b/src/types/actions.lua
@@ -1,4 +1,4 @@
-export type Action<Type = string> = {
+export type Action<Type = any> = {
 	type: Type,
 }
 

--- a/src/types/reducers.lua
+++ b/src/types/reducers.lua
@@ -1,0 +1,7 @@
+local _actions = require(script.Parent.actions)
+
+type AnyAction = _actions.AnyAction
+
+export type Reducer<State = any, Action = AnyAction> = (State?, Action) -> State
+
+return nil

--- a/src/types/reducers.lua
+++ b/src/types/reducers.lua
@@ -1,6 +1,6 @@
-local _actions = require(script.Parent.actions)
+local actions = require(script.Parent.actions)
 
-type AnyAction = _actions.AnyAction
+type AnyAction = actions.AnyAction
 
 export type Reducer<State = any, Action = AnyAction> = (State?, Action) -> State
 

--- a/src/types/reducers.lua
+++ b/src/types/reducers.lua
@@ -4,4 +4,9 @@ type AnyAction = actions.AnyAction
 
 export type Reducer<State = any, Action = AnyAction> = (State?, Action) -> State
 
+export type ReducersMapObject<State = any, Action = AnyAction> = {
+	-- TODO Luau: used to be [K in keyof S]: K[S]
+	[string]: Reducer<State, Action>,
+}
+
 return nil

--- a/src/types/store.lua
+++ b/src/types/store.lua
@@ -1,0 +1,5 @@
+type EmptyObject = {}
+
+export type CombinedState<State> = EmptyObject & State
+
+return nil


### PR DESCRIPTION
Adds Luau types for actions and reducers, directly inspired by upstream [Redux types](https://github.com/reduxjs/redux/tree/0dcb7b53594c7207e543005a5527d4d13c18cc61/src/types/).