### PR TITLE
added freezeMiddleware as well as docs for it

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -287,7 +287,7 @@ store:dispatch(function(store, myCustomArg)
 end)
 ```
 
-### Rodux.freezeMiddlware
+### Rodux.freezeMiddleware
 ```lua
 local store = Store.new(reducer, initialState, { freezeMiddleware.deep })
 ```
@@ -295,7 +295,7 @@ local store = Store.new(reducer, initialState, { freezeMiddleware.deep })
 A function that returns a table of three different middleware functions that prevent you from modifiying the immutable state passed in from the first argument of the reducer. The three functions are `deep`, `shallow`, or `oneLevel` which freeze their respective levels of the table. 
 
 ```lua
-local freezeMiddlware = Rodux.freezeMiddleware
+local freezeMiddleware = Rodux.freezeMiddleware
 
 local reducer = function(state, action)
 	local newState = table.clone(state)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -268,7 +268,7 @@ end)
 ```
 
 ### Rodux.makeThunkMiddleware (unreleased)
-```
+```lua
 Rodux.makeThunkMiddleware(extraArgument) -> thunkMiddleware
 ```
 
@@ -285,6 +285,29 @@ store:dispatch(function(store, myCustomArg)
 		type = "thunkAction"
 	})
 end)
+```
+
+### Rodux.freezeMiddlware
+```lua
+local store = Store.new(reducer, initialState, { freezeMiddleware.deep })
+```
+
+A function that returns a table of three different middleware functions that prevent you from modifiying the immutable state passed in from the first argument of the reducer. The three functions are `deep`, `shallow`, or `oneLevel` which freeze their respective levels of the table. 
+
+```lua
+local freezeMiddlware = Rodux.freezeMiddleware
+
+local reducer = function(state, action)
+	local newState = table.clone(state)
+
+	state.money = 5 
+	--This code will error since you are attempting to modify the 
+	--state table passed in from the reducer and not modifying the clone
+
+	return newState
+end
+
+local store =  Store.new(reducer, initialState, { freezeMiddleware.shallow })
 ```
 
 ## Error Reporters

--- a/src/freezeMiddleware.lua
+++ b/src/freezeMiddleware.lua
@@ -1,0 +1,44 @@
+
+local function deepFreeze(root)
+
+    table.freeze(root)
+    
+    for _, value in root do
+        if typeof(value) == "table" and not table.isfrozen(value) and getmetatable(value) == nil then
+            deepFreeze(value)
+        end
+    end
+    
+end
+
+return {
+    deep = function(nextDispatch, store)
+        return function(action)
+            deepFreeze(store:getState())
+            
+            return nextDispatch(action)
+        end
+    end, 
+    
+    oneLevel = function(nextDispatch, store)
+        return function(action)
+
+            for _, value in store:getState() do
+                if typeof(value) == "table" and not table.isfrozen(value) and getmetatable(value) == nil then
+                    table.freeze(value)
+                end
+            end
+
+            return nextDispatch(action)
+        end
+    end, 
+    
+    shallow = function(nextDispatch, store)
+        return function(action)
+
+            table.freeze(store:getState())
+
+            return nextDispatch(action)
+        end
+    end
+}

--- a/src/init.lua
+++ b/src/init.lua
@@ -6,6 +6,7 @@ local makeActionCreator = require(script.makeActionCreator)
 local loggerMiddleware = require(script.loggerMiddleware)
 local thunkMiddleware = require(script.thunkMiddleware)
 local makeThunkMiddleware = require(script.makeThunkMiddleware)
+local freezeMiddlware = require(script.freezeMiddleware)
 
 local actions = require(script.types.actions)
 local reducers = require(script.types.reducers)
@@ -31,4 +32,5 @@ return {
 	loggerMiddleware = loggerMiddleware.middleware,
 	thunkMiddleware = thunkMiddleware,
 	makeThunkMiddleware = makeThunkMiddleware,
+	freezeMiddlware = freezeMiddlware
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -6,7 +6,7 @@ local makeActionCreator = require(script.makeActionCreator)
 local loggerMiddleware = require(script.loggerMiddleware)
 local thunkMiddleware = require(script.thunkMiddleware)
 local makeThunkMiddleware = require(script.makeThunkMiddleware)
-local freezeMiddlware = require(script.freezeMiddleware)
+local freezeMiddleware = require(script.freezeMiddleware)
 
 local actions = require(script.types.actions)
 local reducers = require(script.types.reducers)
@@ -32,5 +32,5 @@ return {
 	loggerMiddleware = loggerMiddleware.middleware,
 	thunkMiddleware = thunkMiddleware,
 	makeThunkMiddleware = makeThunkMiddleware,
-	freezeMiddlware = freezeMiddlware
+	freezeMiddleware = freezeMiddleware
 }


### PR DESCRIPTION
Added a freezeMiddleware built in to freeze the reducer state table to enforce immutability rules. Previously impossible per issue here https://github.com/Roblox/rodux/issues/16 but as mentioned with the addition of table.clone it was trivial to implement. 

Very small note:

Added the lua tag to the thunk middleware example on line 271 of of the api reference.