### PR TITLE
Only call Signal tracebacks in dev mode

### DIFF
--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -37,7 +37,7 @@ end
 type Listener = {
 	callback: (...any) -> (),
 	disconnected: boolean,
-	connectTraceback: string,
+	connectTraceback: string?,
 	disconnectTraceback: string?,
 }
 

--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -76,9 +76,13 @@ function Signal:connect(callback)
 	local listener: Listener = {
 		callback = callback,
 		disconnected = false,
-		connectTraceback = if __DEV__ then debug.traceback() else nil,
+		connectTraceback = nil,
 		disconnectTraceback = nil,
 	}
+
+	if __DEV__ then
+		listener.connectTraceback = debug.traceback()
+	end
 
 	self._listeners = immutableAppend(self._listeners, listener)
 

--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -76,13 +76,9 @@ function Signal:connect(callback)
 	local listener: Listener = {
 		callback = callback,
 		disconnected = false,
-		connectTraceback = nil,
+		connectTraceback = if __DEV__ then debug.traceback() else nil,
 		disconnectTraceback = nil,
 	}
-
-	if __DEV__ then
-		listener.connectTraceback = debug.traceback()
-	end
 
 	self._listeners = immutableAppend(self._listeners, listener)
 

--- a/src/Signal.lua
+++ b/src/Signal.lua
@@ -5,6 +5,8 @@
 	Handlers are fired in order, and (dis)connections are properly handled when
 	executing an event.
 ]]
+local __DEV__ = _G.__DEV__
+
 local function immutableAppend(list, ...)
 	local new = {}
 	local len = #list
@@ -74,9 +76,13 @@ function Signal:connect(callback)
 	local listener: Listener = {
 		callback = callback,
 		disconnected = false,
-		connectTraceback = debug.traceback(),
+		connectTraceback = nil,
 		disconnectTraceback = nil,
 	}
+
+	if __DEV__ then
+		listener.connectTraceback = debug.traceback()
+	end
 
 	self._listeners = immutableAppend(self._listeners, listener)
 
@@ -94,8 +100,11 @@ function Signal:connect(callback)
 			error("You may not unsubscribe from a store listener while the reducer is executing.")
 		end
 
+		if __DEV__ then
+			listener.disconnectTraceback = debug.traceback()
+		end
+
 		listener.disconnected = true
-		listener.disconnectTraceback = debug.traceback()
 		self._listeners = immutableRemoveValue(self._listeners, listener)
 	end
 


### PR DESCRIPTION
Moves Signal connect() and disconnect() tracebacks under a dev flag. The remaining debug.traceback() calls will all immediately throw an error, so there's no point in calling them conditionally.