### PR TITLE
Adds support for non-string error objects to be caught by NoYield

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,6 +1,6 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "7.2.0" }
-selene = { source = "Kampfkarren/selene", version = "0.18.1" }
-stylua = { source = "JohnnyMorganz/StyLua", version = "0.13.1" }
+selene = { source = "Kampfkarren/selene", version = "0.21.1" }
+stylua = { source = "JohnnyMorganz/StyLua", version = "0.15.1" }
 luau-lsp = { source = "JohnnyMorganz/luau-lsp", version = "*" }
 wally = { source = "UpliftGames/wally", version = "0.3.1" }

--- a/src/NoYield.lua
+++ b/src/NoYield.lua
@@ -10,8 +10,15 @@
 
 local function resultHandler(co: thread, ok: boolean, ...)
 	if not ok then
-		local message = (...)
-		error(debug.traceback(co, message), 2)
+		local err = (...)
+		if typeof(err) == "string" then
+			error(debug.traceback(co, err), 2)
+		else
+			-- If the error is not of type string, just assume it has some
+			-- meaningful information and rethrow it with a `tostring` so that
+			-- top-level error handlers can process it
+			error(tostring(err), 2)
+		end
 	end
 
 	if coroutine.status(co) ~= "dead" then

--- a/src/NoYield.spec.lua
+++ b/src/NoYield.spec.lua
@@ -53,4 +53,30 @@ return function()
 		expect(err:find("foo")).to.be.ok()
 		expect(err:find("NoYield.spec")).to.be.ok()
 	end)
+
+	it("should handle non-string error messages", function()
+		local count = 0
+
+		local function makeErrorObject()
+			return setmetatable({
+				message = "errored with an error object",
+				stack = debug.traceback(),
+			}, {
+				__tostring = function(self)
+					return self.message .. "\n" .. self.stack
+				end,
+			})
+		end
+
+		local function test()
+			count = count + 1
+			error(makeErrorObject())
+		end
+
+		local ok, err = pcall(NoYield, test)
+
+		expect(ok).to.equal(false)
+		expect(err:find("errored with an error object")).to.be.ok()
+		expect(err:find("NoYield.spec")).to.be.ok()
+	end)
 end

--- a/src/makeActionCreator.lua
+++ b/src/makeActionCreator.lua
@@ -7,10 +7,7 @@ local actions = require(script.Parent.types.actions)
 
 export type ActionCreator<Type, Action, Args...> = actions.ActionCreator<Type, Action, Args...>
 
-local function makeActionCreator<Type, Action, Args...>(
-	name: Type,
-	fn: (Args...) -> Action
-): ActionCreator<Type, Action, Args...>
+local function makeActionCreator<Type, Action, Args...>(name: Type, fn: (Args...) -> Action): ActionCreator<Type, Action, Args...>
 	assert(type(name) == "string", "Bad argument #1: Expected a string name for the action creator")
 
 	assert(type(fn) == "function", "Bad argument #2: Expected a function that creates action objects")


### PR DESCRIPTION
This behavior is valid in Luau, but I suspect it won't work (and/or won't be easily testable) in our lemur setup. We may have to adapt the test in order to properly simulate it.

The CI interactions here are a bit misleading:
* our internal analysis tool understands this without issue, but it looks like luau-lsp is assuming that `script.Parent` could be nil despite using the project mapping
* I don't know for sure that this test runs in a representative way via lemur, but it passes with roblox-cli