### PR TITLE
APT-606 - Change Foreman To Install Internal Mirrors Instead Of External Tools

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,7 +1,7 @@
 [tools]
-rojo = { source = "rojo-rbx/rojo", version = "=7.3.0" }
-selene = { source = "Kampfkarren/selene", version = "=0.25.0" }
-stylua = { source = "JohnnyMorganz/StyLua", version = "=0.18.1" }
+rojo = { source = "Roblox/rojo-rbx-rojo", version = "=7.3.0" }
+selene = { source = "Roblox/Kampfkarren-selene", version = "=0.25.0" }
+stylua = { source = "Roblox/JohnnyMorganz-StyLua", version = "=0.18.1" }
 luau-lsp = { source = "JohnnyMorganz/luau-lsp", version = "=1.23.0" }
 wally = { source = "UpliftGames/wally", version = "=0.3.2" }
 darklua = { source = "seaofvoices/darklua", version = "=0.10.2"}


### PR DESCRIPTION
Foreman should install from internal mirrors instead of arbitrary binaries from external github releases

[_Created by Sourcegraph batch change `afujiwara/APT-606-changing-external-tool-dependencies-to-internal-mirrors-foreman`._](https://sourcegraph.rbx.com/users/afujiwara/batch-changes/APT-606-changing-external-tool-dependencies-to-internal-mirrors-foreman)