### PR TITLE
update mkdocs config for theme toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,25 +7,31 @@ theme:
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
+      primary: 'Light Blue'
+      accent: 'Light Blue'
       toggle:
         icon: material/brightness-auto
         name: Switch to light mode
 
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
-      scheme: default 
+      primary: 'Light Blue'
+      accent: 'Light Blue'
+      scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
 
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
+      primary: 'Light Blue'
+      accent: 'Light Blue'
       scheme: slate
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
 
-pages:
+nav:
   - Home: index.md
   - Introduction:
     - Installation: introduction/installation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,25 @@ repo_url: https://github.com/Roblox/rodux
 theme:
   name: material
   palette:
-    primary: 'Light Blue'
-    accent: 'Light Blue'
-    scheme: preference
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 
 pages:
   - Home: index.md


### PR DESCRIPTION
This only adds dark/light toggle for the material theme in mkdocs.

This can be viewed here [https://gyfdb.github.io/rodux/](https://gyfdb.github.io/rodux/).